### PR TITLE
Add support for smarter handling of fixed barcode lengths.

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,22 @@ const removeScanListener = barcodeScanListener.onScan({
 removeScanListener()
 ```
 
+#### `barcodeLength`
+If your barcodes have a known, fixed length, eliminate partial scans and double scans
+by passng in `barcodeLength` - your callback will only be called if `barcodeLength`
+number of characters are reached, and any characters read past that length before
+`scanDuration` is reached will be ignored.
+
+```js
+barcodeScanListener.onScan({
+  barcodePrefix: 'L%',
+  barcodeLength: 24,
+  scanDuration: 500
+}, function (barcode) {
+  console.log(barcode);
+});
+```
+
 ## Contributing
 
 This module is written in ES2015 and converted to node-friendly CommonJS via

--- a/src/index.js
+++ b/src/index.js
@@ -4,13 +4,18 @@ export default {
   /**
    * Listen for scan with specified characteristics
    * @param  {String} scanCharacteristics.barcodePrefix
+   * @param  {Number} [scanCharacteristics.barcodeLength] - if provided, the listener will
+   * wait for this many characters to be read before calling the handler
    * @param  {Number} [scanCharacteristics.scanDuration]
    * @param  {Function} scanHandler - called with the results of the scan
    * @return {Function} remove this listener
    */
-  onScan ({barcodePrefix, scanDuration} = {}, scanHandler) {
+  onScan ({barcodePrefix, barcodeLength, scanDuration} = {}, scanHandler) {
     if (typeof barcodePrefix !== 'string') {
       throw new TypeError('barcodePrefix must be a string');
+    }
+    if (barcodeLength && typeof barcodeLength !== 'number') {
+      throw new TypeError('barcodeLength must be a number');
     }
     if (scanDuration && typeof scanDuration !== 'number') {
       throw new TypeError('scanDuration must be a number');
@@ -43,7 +48,10 @@ export default {
     let scannedPrefix = '';
     const finishScan = function () {
       if (codeBuffer) {
-        scanHandler(codeBuffer);
+        if (!barcodeLength)
+          scanHandler(codeBuffer);
+        else if (codeBuffer.length >= barcodeLength)
+          scanHandler(codeBuffer.substr(0, barcodeLength));
       }
       scannedPrefix = '';
       codeBuffer = '';

--- a/test/test.js
+++ b/test/test.js
@@ -35,6 +35,14 @@ describe('barcodeScanListener.onScan()', function () {
       expect(createOnScan).to.throw('scanHandler must be a function');
     });
 
+    it('errors if barcodeLength not a number', function () {
+      const createOnScan = () => barcodeScanListener.onScan({
+        barcodePrefix: 'L%',
+        barcodeLength: '24'
+      }, sinon.stub());
+      expect(createOnScan).to.throw('barcodeLength must be a number');
+    });
+
     it('errors if scan duration not a number', function () {
       const createOnScan = () => barcodeScanListener.onScan({
         barcodePrefix: 'L%',
@@ -58,6 +66,31 @@ describe('barcodeScanListener.onScan()', function () {
       barcodeScanListener.onScan({barcodePrefix: 'L%'}, scanHandler);
       scanBarcode('C%123abc')
       expect(scanHandler).not.to.have.been.called()
+    });
+  });
+
+  describe('barcodeLength', function () {
+    it('does not call handler for scanned barcode shorter than configured length', function () {
+      const scanHandler = sinon.stub()
+      barcodeScanListener.onScan({barcodePrefix: 'L%', barcodeLength: 7}, scanHandler);
+      scanBarcode('L%123abc')
+      expect(scanHandler).not.to.have.been.called()
+    });
+
+    it('calls handler with truncated barcode for scanned barcode greater than configured length', function () {
+      const scanHandler = sinon.stub()
+      barcodeScanListener.onScan({barcodePrefix: 'L%', barcodeLength: 5}, scanHandler);
+      scanBarcode('L%123abc')
+      expect(scanHandler).to.have.been.calledOnce()
+      expect(scanHandler).to.have.been.calledWith('123ab')
+    });
+
+    it('calls handler for scanned barcode with configured length', function () {
+      const scanHandler = sinon.stub()
+      barcodeScanListener.onScan({barcodePrefix: 'L%', barcodeLength: 6}, scanHandler);
+      scanBarcode('L%123abc')
+      expect(scanHandler).to.have.been.calledOnce()
+      expect(scanHandler).to.have.been.calledWith('123abc')
     });
   });
 


### PR DESCRIPTION
If the barcode length is known, pass in `barcodeLength` and the handler will only be called if `barcodeLength` number of characters are reached, and any characters read past that length before the scan duration timeout will be ignored.

This entirely eliminates two classes of bad scans: partial scans (only a substring of the barcode was read) and double scans (the barcode was scanned twice in quick succession, interpreted as one long barcode by this code).

cc @goodeggs/ops-tools
