### PR TITLE
Validate barcode scan values.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,7 @@
+# [2.0.0](https://github.com/goodeggs/barcode-scan-listener/compare/v1.2.0...v2.0.0)
+
+### BREAKING CHANGES
+
+* `barcodeOptions.barcodeValueTest` arg required.
+* `barcodeOptions.barcodeLength` removed in favor of `barcodeValueTest` and `finishScanOnMatch`.
+* SwipeTrack scan listener extracted into separate module [swipetrack-barcode-scan-listener](https://github.com/goodeggs/swipetrack-barcode-scan-listener)

--- a/README.md
+++ b/README.md
@@ -12,31 +12,18 @@ import barcodeScanListener from 'barcode-scan-listener';
 
 const removeScanListener = barcodeScanListener.onScan({
   barcodePrefix: 'L%',
+  barcodeValueTest: /^123$/,
+  finishScanOnMatch: true,
   scanDuration: 500
 }, function (barcode) {
   console.log(barcode);
 });
 
-// Now, scanning a barcode 'L%123abc' will log '123abc'
+// Now, scanning a barcode 'L%123abc' will log '123'
 
 removeScanListener()
 ```
 
-#### `barcodeLength`
-If your barcodes have a known, fixed length, eliminate partial scans and double scans
-by passng in `barcodeLength` - your callback will only be called if `barcodeLength`
-number of characters are reached, and any characters read past that length before
-`scanDuration` is reached will be ignored.
-
-```js
-barcodeScanListener.onScan({
-  barcodePrefix: 'L%',
-  barcodeLength: 24,
-  scanDuration: 500
-}, function (barcode) {
-  console.log(barcode);
-});
-```
 
 ## Contributing
 


### PR DESCRIPTION
- Add `scanOptions.barcodeValueTest`. The scanHandler will not be called unless the scan value (not including the prefix) matches this RegExp.
- Add `scanOptions.finishScanOnMatch`, which tests on each keypress for a `barcodeValueTest` match and calls the scan handler on success. Enabling this option reduces scan delay.
- Remove `scanOptions.barcodeLength`. We can achieve the same functionality through a combination of  `barcodeValueTest` and `finishScanOnMatch`.
- Extract swipetrack scan logic into a separate [swipetrack-barcode-scan-listener](https://github.com/goodeggs/swipetrack-barcode-scan-listener) module. It feels better to have the two separate since this module is open source. I plan to combine the two modules in `goodeggs-barcode-scan-listener`.

For instance, to match a lot scan:

``` js
barcodeScanListener.onScan({
  barcodePrefix: 'L%',
  barcodeValueTest: /^[a-f\d]{24}$/,
  finishScanOnMatch: true,
  scanDuration: 500
}, function (barcode) {
  console.log(barcode);
});
```

This will call the scan handler immediately once the scanner enters a 24 character objectId. If the scan value is an invalid objectId, the handler will not be called.

cc @goodeggs/ops-tools 
