### PR TITLE
Support empty barcode values.

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -31,34 +31,42 @@ export default {
 
     scanDuration = scanDuration || 50;
     let finishScanTimeoutId = null;
-    let codeBuffer = '';
-    let scannedPrefix = '';
+    let prefixBuffer = '';
+    let valueBuffer = '';
+    let matchedPrefix = false;
     const finishScan = function () {
-      if (codeBuffer && barcodeValueTest.test(codeBuffer)) {
-        scanHandler(codeBuffer);
+      if (matchedPrefix && barcodeValueTest.test(valueBuffer)) {
+        scanHandler(valueBuffer);
       }
       resetScanState();
     };
     const resetScanState = function () {
       finishScanTimeoutId = null;
-      scannedPrefix = '';
-      codeBuffer = '';
+      prefixBuffer = '';
+      valueBuffer = '';
+      matchedPrefix = false;
     };
     const keypressHandler = function (e) {
       const char = String.fromCharCode(e.which);
       const charIndex = barcodePrefix.indexOf(char);
-      const expectedPrefix = barcodePrefix.slice(0, charIndex);
+      const expectedPrefixSlice = barcodePrefix.slice(0, charIndex);
+
       if (!finishScanTimeoutId) {
         finishScanTimeoutId = setTimeout(finishScan, scanDuration);
       }
-      if (scannedPrefix === barcodePrefix && /[^\s]/.test(char)) {
-        codeBuffer += char;
-        if (finishScanOnMatch && barcodeValueTest.test(codeBuffer)) {
+
+      if (prefixBuffer === expectedPrefixSlice && char === barcodePrefix.charAt(charIndex)) {
+        prefixBuffer += char;
+      } else if (matchedPrefix) {
+        valueBuffer += char;
+      }
+
+      if (prefixBuffer === barcodePrefix) {
+        matchedPrefix = true;
+        if (finishScanOnMatch && barcodeValueTest.test(valueBuffer)) {
           clearTimeout(finishScanTimeoutId);
           finishScan();
         }
-      } else if (scannedPrefix === expectedPrefix && char === barcodePrefix.charAt(charIndex)) {
-        scannedPrefix += char;
       }
     };
     const removeListener = function () {

--- a/test/test.js
+++ b/test/test.js
@@ -104,6 +104,17 @@ describe('barcodeScanListener.onScan()', function () {
       scanBarcode('C%213abc');
       expect(scanHandler).not.to.have.been.called();
     });
+
+    it('supports empty value', function () {
+      const scanHandler = sinon.stub();
+      barcodeScanListener.onScan({
+        barcodePrefix: 'L%',
+        barcodeValueTest: /^$/,
+      }, scanHandler);
+      scanBarcode('L%');
+      expect(scanHandler).to.have.been.calledOnce();
+      expect(scanHandler).to.have.been.calledWith('');
+    });
   });
 
   describe('finishScanOnMatch', function () {


### PR DESCRIPTION
e.g. 'M%' where the prefix is 'M%' and the desired value is ''

Also rename some variables for clarity.